### PR TITLE
Add failover transport protocol related GraalVM configs

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "activemq.driver"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Ballerina"]
 keywords = ["ActiveMQ"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-activemq.driver"
@@ -32,5 +32,5 @@ path = "./lib/hawtbuf-1.11.jar"
 [[platform.java17.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "activemq.driver-native"
-version = "1.0.1"
-path = "../native/build/libs/activemq.driver-native-1.0.1.jar"
+version = "1.0.2"
+path = "../native/build/libs/activemq.driver-native-1.0.2-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.8.0"
 [[package]]
 org = "ballerinax"
 name = "activemq.driver"
-version = "1.0.1"
+version = "1.0.2"
 modules = [
 	{org = "ballerinax", packageName = "activemq.driver", moduleName = "activemq.driver"}
 ]

--- a/native/src/main/resources/META-INF/native-image/io.ballerina.stdlib/activemq.driver-native/reflect-config.json
+++ b/native/src/main/resources/META-INF/native-image/io.ballerina.stdlib/activemq.driver-native/reflect-config.json
@@ -593,6 +593,15 @@
           ]
         }
       ]
+    },
+    {
+      "name":"org.apache.activemq.transport.failover.FailoverTransportFactory",
+      "methods":[
+        {
+          "name":"<init>",
+          "parameterTypes":[] 
+        }
+      ]
     }
   ]
   

--- a/native/src/main/resources/META-INF/native-image/io.ballerina.stdlib/activemq.driver-native/resource-config.json
+++ b/native/src/main/resources/META-INF/native-image/io.ballerina.stdlib/activemq.driver-native/resource-config.json
@@ -14,6 +14,9 @@
           }
         },
         {
+          "pattern":"\\QMETA-INF/services/org/apache/activemq/transport/failover\\E"
+        },
+        {
           "pattern": "\\Qorg/apache/activemq/version.txt\\E",
           "condition": {
             "typeReachable": "org.apache.activemq.broker.BrokerService"


### PR DESCRIPTION
## Purpose
> $subject

Fixes: [#7394](https://github.com/ballerina-platform/ballerina-library/issues/7394)

## Examples

```ballerina
import ballerinax/java.jms;
import ballerina/log;
import ballerinax/activemq.driver as _;

service on new jms:Listener(
    connectionConfig = {
        initialContextFactory: "org.apache.activemq.jndi.ActiveMQInitialContextFactory",
        providerUrl: "failover:(tcp://localhost:61616)",
        username: "artemis",
        password: "artemis"
    },
    consumerOptions = {
        destination: {
            'type: jms:QUEUE,
            name: "order-queue"
        }
    }
) {
    remote function onMessage(jms:Message message) returns error? {
        if message is jms:MapMessage {
            log:printInfo("Order message received", content = message.content.toString());
        }
    }
}
```

## Checklist
- [X] Linked to an issue
- [ ] ~Updated the specification~
- [ ] Updated the changelog
- [ ] ~Added tests~
- [x] Checked native-image compatibility
