### PR TITLE
Bump activemq-client to 5.18.7 to fix CVE-2025-27533

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -15,8 +15,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "org.apache.activemq"
 artifactId = "activemq-client"
-version = "5.18.3"
-path = "./lib/activemq-client-5.18.3.jar"
+version = "5.18.7"
+path = "./lib/activemq-client-5.18.7.jar"
 
 [[platform.java21.dependency]]
 groupId = "org.apache.geronimo.specs"

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,6 @@ ballerinaLangVersion=2201.11.0
 ballerinaGradlePluginVersion=2.3.0
 releasePluginVersion=2.8.0
 
-activemqClientVersion=5.18.3
+activemqClientVersion=5.18.7
 geronimoJ2eeMng11SpecVersion=1.0.1
 hawtbufVersion=1.11


### PR DESCRIPTION
## Summary
- Bumps `org.apache.activemq:activemq-client` from `5.18.3` to `5.18.7`
- Fixes CVE-2025-27533 (MEDIUM): Unvalidated Buffer Size Allocation vulnerability in ActiveMQ client

## Test plan
- [ ] Build passes without test failures
- [ ] `ballerina/Ballerina.toml` reflects `5.18.7` for activemq-client dependency
- [ ] Trivy scan no longer reports CVE-2025-27533

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request updates the Apache ActiveMQ client dependency to improve the security and stability of the module. The `org.apache.activemq:activemq-client` dependency is bumped from version 5.18.3 to 5.18.7 across the build configuration.

## Changes

- **ballerina/Ballerina.toml**: Updated the `org.apache.activemq:activemq-client` platform dependency for Java 21 from `5.18.3` to `5.18.7`, including the corresponding local JAR path reference.
- **gradle.properties**: Updated the `activemqClientVersion` property from `5.18.3` to `5.18.7` to align with the Gradle build configuration.

These changes ensure that the module uses a more recent version of the ActiveMQ client library that addresses known stability and security concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->